### PR TITLE
Changes so that the plugin can follow the current buffer path

### DIFF
--- a/doc/tags
+++ b/doc/tags
@@ -1,0 +1,7 @@
+openingh	openingh.txt	/*openingh*
+openingh-commands	openingh.txt	/*openingh-commands*
+openingh-introduction	openingh.txt	/*openingh-introduction*
+openingh-license	openingh.txt	/*openingh-license*
+openingh-requirements	openingh.txt	/*openingh-requirements*
+openingh-usage	openingh.txt	/*openingh-usage*
+openingh.txt	openingh.txt	/*openingh.txt*

--- a/lua/openingh/init.lua
+++ b/lua/openingh/init.lua
@@ -2,7 +2,9 @@ local utils = require("openingh.utils")
 local M = {}
 
 function M.setup()
-  local repo_url = vim.fn.system("git config --get remote.origin.url")
+  -- get the current working directory and set the url
+  local current_buffer = vim.fn.expand('%:p:h')
+  local repo_url = vim.fn.system("git -C " ..current_buffer.. " config --get remote.origin.url" )
 
   if repo_url:len() == 0 then
     M.is_no_git_origin = true
@@ -19,6 +21,8 @@ function M.setup()
 end
 
 function M.openFile()
+  -- make sure to update the current directory
+  M.setup()
   if M.is_no_git_origin then
     utils.print_no_remote_message()
     return
@@ -45,6 +49,8 @@ function M.openFile()
 end
 
 function M.openRepo()
+  -- make sure to update the current directory
+  M.setup()
   if M.is_no_git_origin then
     utils.print_no_remote_message()
     return

--- a/plugin/openingh.lua
+++ b/plugin/openingh.lua
@@ -6,7 +6,7 @@ vim.g.openingh = true
 require("openingh").setup()
 
 vim.api.nvim_create_user_command("OpenInGHFile", function()
-  require("openingh").openFile()
+  require("openingh"):openFile()
 end, {})
 
 vim.api.nvim_create_user_command("OpenInGHRepo", function()


### PR DESCRIPTION
Simple change to make the plugin follow your current buffer directory instead of the path defined by your terminal.

When you try to open a file that is in another git repo, the plugin does not updates the new path, instead just opens the old repo.
You can make it optional too :) .