### PR TITLE
Improve startup time

### DIFF
--- a/plugin/openingh.lua
+++ b/plugin/openingh.lua
@@ -3,12 +3,12 @@ if vim.g.openingh then
 end
 vim.g.openingh = true
 
-require("openingh").setup()
+local openingh = require("openingh")
 
 vim.api.nvim_create_user_command("OpenInGHFile", function()
-  require("openingh"):openFile()
+  openingh:openFile()
 end, {})
 
 vim.api.nvim_create_user_command("OpenInGHRepo", function()
-  require("openingh"):openRepo()
+  openingh:openRepo()
 end, {})


### PR DESCRIPTION
Calling `.setup()` in `plugin/openingh.lua` seems to slow down nvim startup time significantly.

#### Before

```
       startup: 536.6ms
event                  time percent plot
openingh.lua         310.14   57.79 ██████████████████████████
init.lua             158.75   29.58 █████████████▎
telescope._extension  24.86    4.63 ██▏
```

#### After
```
       startup: 209.6ms
event                  time percent plot
init.lua             146.52   69.89 ██████████████████████████
telescope._extension  20.83    9.93 ███▊
luasnip               14.54    6.93 ██▋
```