### PR TITLE
Added support for ranges when opening a file

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,11 +48,11 @@ You can call the commands directly or define mappings them:
 
 ```lua
 -- for repository page
-vim.api.nvim_set_keymap("n", "<Leader>gr", ":OpenInGHRepo <CR>", { expr = true, noremap = true })
+vim.api.nvim_set_keymap("n", "<Leader>gr", ":OpenInGHRepo <CR>", { silent = true, noremap = true })
 
 -- for current file page
-vim.api.nvim_set_keymap("n", "<Leader>gf", ":OpenInGHFile <CR>", { expr = true, noremap = true })
-vim.api.nvim_set_keymap("v", "<Leader>gf", "<esc><cmd>'<,'>OpenInGHFile <CR>", { expr = true, noremap = true })
+vim.api.nvim_set_keymap("n", "<Leader>gf", ":OpenInGHFile <CR>", { silent = true, noremap = true })
+vim.api.nvim_set_keymap("v", "<Leader>gf", ":OpenInGHFile <CR>", { silent = true, noremap = true })
 ```
 
 ## TODO

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ end)
   - Opens the project's git repository page in GitHub.
 
 - `:OpenInGHFile`
-  - Opens the current file page in GitHub.
+  - Opens the current file page in GitHub.  This command supports ranges.
 
 ## Usage
 
@@ -52,6 +52,7 @@ vim.api.nvim_set_keymap("n", "<Leader>gr", ":OpenInGHRepo <CR>", { expr = true, 
 
 -- for current file page
 vim.api.nvim_set_keymap("n", "<Leader>gf", ":OpenInGHFile <CR>", { expr = true, noremap = true })
+vim.api.nvim_set_keymap("v", "<Leader>gf", "<esc><cmd>'<,'>OpenInGHFile <CR>", { expr = true, noremap = true })
 ```
 
 ## TODO

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ vim.api.nvim_set_keymap("v", "<Leader>gf", "<esc><cmd>'<,'>OpenInGHFile <CR>", {
 ## TODO
 
   - [x] Support the current file cursor position
-  - [ ] Support visual mode to open a file in range selection 
+  - [x] Support visual mode to open a file in range selection 
   - [x] Support other version control websites 
 
 ## Contribution

--- a/lua/openingh/init.lua
+++ b/lua/openingh/init.lua
@@ -38,7 +38,7 @@ function M.openFile(range_start, range_end)
     return
   end
 
-  local lines = nil
+  local lines
 
   if range_start and range_end then
     lines = "#L" .. range_start .. "-" .. "L" .. range_end

--- a/lua/openingh/init.lua
+++ b/lua/openingh/init.lua
@@ -22,7 +22,7 @@ function M.setup()
   M.repo_url = string.format("http://%s/%s/%s", gh.host, gh.user_or_org, gh.reponame)
 end
 
-function M.openFile()
+function M.openFile(range_start, range_end)
   -- make sure to update the current directory
   M.setup()
   if M.is_no_git_origin then
@@ -38,10 +38,17 @@ function M.openFile()
     return
   end
 
-  local line_number = utils.get_line_number_from_buf()
+  local lines = nil
+
+  if range_start and range_end then
+    lines = "#L" .. range_start .. "-" .. "L" .. range_end
+  else
+    lines = "#L" .. utils.get_line_number_from_buf()
+  end
+
   local current_branch_name_or_commit_hash = utils.get_current_branch_or_commit()
 
-  local file_page_url = M.repo_url .. "/blob/" .. current_branch_name_or_commit_hash .. file_path .. "#L" .. line_number
+  local file_page_url = M.repo_url .. "/blob/" .. current_branch_name_or_commit_hash .. file_path .. lines
 
   local result = utils.open_url(file_page_url)
 

--- a/plugin/openingh.lua
+++ b/plugin/openingh.lua
@@ -16,5 +16,5 @@ end, {
 })
 
 vim.api.nvim_create_user_command("OpenInGHRepo", function()
-  openingh:openRepo()
+  openingh.openRepo()
 end, {})

--- a/plugin/openingh.lua
+++ b/plugin/openingh.lua
@@ -5,9 +5,15 @@ vim.g.openingh = true
 
 local openingh = require("openingh")
 
-vim.api.nvim_create_user_command("OpenInGHFile", function()
-  openingh:openFile()
-end, {})
+vim.api.nvim_create_user_command("OpenInGHFile", function(opts)
+  if opts.range == 0 or opts.range == 1 then
+    openingh.openFile()
+  else
+    openingh.openFile(opts.line1, opts.line2)
+  end
+end, {
+  range = true,
+})
 
 vim.api.nvim_create_user_command("OpenInGHRepo", function()
   openingh:openRepo()

--- a/tests/openingh_spec.lua
+++ b/tests/openingh_spec.lua
@@ -50,4 +50,13 @@ describe("openingh should open", function()
     local expected = "/README.md#L5-L10"
     assert.equal(expected, status:sub(-#expected))
   end)
+
+  it("file range using a keymap", function()
+    vim.cmd("e ./README.md")
+    vim.api.nvim_set_keymap("n", "ghf", ":OpenInGHFile <cr>", {})
+    vim.cmd("normal ghf")
+    local status = vim.g.OPENINGH_RESULT
+    local expected = "/README.md#L1"
+    assert.equal(expected, status:sub(-#expected))
+  end)
 end)

--- a/tests/openingh_spec.lua
+++ b/tests/openingh_spec.lua
@@ -37,7 +37,7 @@ describe("openingh should open", function()
     vim.api.nvim_win_set_cursor(0, { 3, 0 })
     vim.cmd("OpenInGHFile")
     local status = vim.g.OPENINGH_RESULT
-    local expected = "/blob/main/README.md#L3"
+    local expected = "/README.md#L3"
     assert.equal(expected, status:sub(-#expected))
   end)
 
@@ -47,7 +47,7 @@ describe("openingh should open", function()
     vim.api.nvim_buf_set_mark(0, ">", 10, 0, {})
     vim.cmd("'<,'>OpenInGHFile")
     local status = vim.g.OPENINGH_RESULT
-    local expected = "/blob/main/README.md#L5-L10"
+    local expected = "/README.md#L5-L10"
     assert.equal(expected, status:sub(-#expected))
   end)
 end)

--- a/tests/openingh_spec.lua
+++ b/tests/openingh_spec.lua
@@ -34,9 +34,20 @@ describe("openingh should open", function()
 
   it("file on :OpenInGHFile", function()
     vim.cmd("e ./README.md")
+    vim.api.nvim_win_set_cursor(0, { 3, 0 })
     vim.cmd("OpenInGHFile")
-
     local status = vim.g.OPENINGH_RESULT
-    assert.truthy(status)
+    local expected = "/blob/main/README.md#L3"
+    assert.equal(expected, status:sub(-#expected))
+  end)
+
+  it("file range on :'<,'>OpenInGHFile", function()
+    vim.cmd("e ./README.md")
+    vim.api.nvim_buf_set_mark(0, "<", 5, 0, {})
+    vim.api.nvim_buf_set_mark(0, ">", 10, 0, {})
+    vim.cmd("'<,'>OpenInGHFile")
+    local status = vim.g.OPENINGH_RESULT
+    local expected = "/blob/main/README.md#L5-L10"
+    assert.equal(expected, status:sub(-#expected))
   end)
 end)

--- a/tests/openingh_spec.lua
+++ b/tests/openingh_spec.lua
@@ -52,11 +52,12 @@ describe("openingh should open", function()
   end)
 
   it("file range using a keymap", function()
-    vim.cmd("e ./README.md")
     vim.api.nvim_set_keymap("n", "ghf", ":OpenInGHFile <cr>", {})
+    vim.cmd("e ./README.md")
+    vim.api.nvim_win_set_cursor(0, { 2, 0 })
     vim.cmd("normal ghf")
     local status = vim.g.OPENINGH_RESULT
-    local expected = "/README.md#L1"
+    local expected = "/README.md#L2"
     assert.equal(expected, status:sub(-#expected))
   end)
 end)


### PR DESCRIPTION
I wanted to support for selecting a range in nvim and opening the corresponding lines as selected in git (e.g. https://github.com/lvauthrin/openingh.nvim/blob/0882b3d798edd64c7fc9611cfce5bb9e383944e4/lua/openingh/init.lua#L43-L47).  To support this, I added two optional parameters to the `openFile` function.  This allows you to either call the command directly with a range or use configure it with a keymap function like this:
```lua
function()
  local curpos = vim.fn.getcurpos()
  local r_start = vim.fn.line("v")
  local r_end = curpos[2]

  if r_start > r_end then
    r_start, r_end = r_end, r_start
  end

  if r_start == r_end then
    vim.api.nvim_command(":OpenInGHFile")
  else
    vim.api.nvim_command(":" .. r_start .. "," .. r_end .. "OpenInGHFile")
  end
end
```

or like this:
```lua
vim.api.nvim_set_keymap("n", "<Leader>gr", "<cmd>OpenInGHFile<cr>", { expr = true, noremap = true })
vim.api.nvim_set_keymap("n", "<Leader>gr", "<esc><cmd>'<,'>OpenInGHFile<cr>", { expr = true, noremap = true })

```

I'm not sure if there's a way to combine the keymaps into a single command though.