### PR TITLE
Do not append lines to the URL when nothing is selected

### DIFF
--- a/lua/openingh/init.lua
+++ b/lua/openingh/init.lua
@@ -22,7 +22,12 @@ function M.setup()
   M.repo_url = string.format("http://%s/%s/%s", gh.host, gh.user_or_org, gh.reponame)
 end
 
-function M.openFile(range_start, range_end)
+function M.open_file(
+  --[[optional]]
+  range_start,
+  --[[optional]]
+  range_end
+)
   -- make sure to update the current directory
   M.setup()
   if M.is_no_git_origin then
@@ -38,17 +43,11 @@ function M.openFile(range_start, range_end)
     return
   end
 
-  local lines
+  local file_page_url = M.repo_url .. "/blob/" .. utils.get_current_branch_or_commit() .. file_path
 
   if range_start and range_end then
-    lines = "#L" .. range_start .. "-" .. "L" .. range_end
-  else
-    lines = "#L" .. utils.get_line_number_from_buf()
+    file_page_url = file_page_url .. "#L" .. range_start .. "-L" .. range_end
   end
-
-  local current_branch_name_or_commit_hash = utils.get_current_branch_or_commit()
-
-  local file_page_url = M.repo_url .. "/blob/" .. current_branch_name_or_commit_hash .. file_path .. lines
 
   local result = utils.open_url(file_page_url)
 

--- a/lua/openingh/init.lua
+++ b/lua/openingh/init.lua
@@ -56,7 +56,7 @@ function M.open_file(
   end
 end
 
-function M.openRepo()
+function M.open_repo()
   -- make sure to update the current directory
   M.setup()
   if M.is_no_git_origin then

--- a/lua/openingh/utils.lua
+++ b/lua/openingh/utils.lua
@@ -38,7 +38,7 @@ function M.parse_gh_remote(url)
 end
 
 -- get the remote default branch
-function M.get_defualt_branch()
+function M.get_default_branch()
   -- will return origin/[branch_name]
   local branch_with_origin = vim.fn.system("git rev-parse --abbrev-ref origin/HEAD")
   local branch_name = M.split(branch_with_origin, "/")[2]
@@ -72,8 +72,8 @@ end
 
 -- get the line number in the buffer
 function M.get_line_number_from_buf()
-  local lineNum = vim.api.nvim_win_get_cursor(0)[1]
-  return lineNum
+  local line_num = vim.api.nvim_win_get_cursor(0)[1]
+  return line_num
 end
 
 -- opens a url in the correct OS

--- a/plugin/openingh.lua
+++ b/plugin/openingh.lua
@@ -6,10 +6,10 @@ vim.g.openingh = true
 local openingh = require("openingh")
 
 vim.api.nvim_create_user_command("OpenInGHFile", function(opts)
-  if opts.range == 0 or opts.range == 1 then
-    openingh.openFile()
-  else
-    openingh.openFile(opts.line1, opts.line2)
+  if opts.range == 0 then -- Nothing was selected
+    openingh.open_file()
+  else -- Current line or block was selected
+    openingh.open_file(opts.line1, opts.line2)
   end
 end, {
   range = true,

--- a/plugin/openingh.lua
+++ b/plugin/openingh.lua
@@ -16,5 +16,5 @@ end, {
 })
 
 vim.api.nvim_create_user_command("OpenInGHRepo", function()
-  openingh.openRepo()
+  openingh.open_repo()
 end, {})

--- a/tests/openingh_spec.lua
+++ b/tests/openingh_spec.lua
@@ -37,7 +37,17 @@ describe("openingh should open", function()
     vim.api.nvim_win_set_cursor(0, { 3, 0 })
     vim.cmd("OpenInGHFile")
     local status = vim.g.OPENINGH_RESULT
-    local expected = "/README.md#L3"
+    local expected = "/README.md"
+    assert.equal(expected, status:sub(-#expected))
+  end)
+
+  it("file range on :'<,'>OpenInGHFile", function()
+    vim.cmd("e ./README.md")
+    vim.api.nvim_buf_set_mark(0, "<", 5, 0, {})
+    vim.api.nvim_buf_set_mark(0, ">", 5, 0, {})
+    vim.cmd("'<,'>OpenInGHFile")
+    local status = vim.g.OPENINGH_RESULT
+    local expected = "/README.md#L5-L5"
     assert.equal(expected, status:sub(-#expected))
   end)
 
@@ -57,7 +67,7 @@ describe("openingh should open", function()
     vim.api.nvim_win_set_cursor(0, { 2, 0 })
     vim.cmd("normal ghf")
     local status = vim.g.OPENINGH_RESULT
-    local expected = "/README.md#L2"
+    local expected = "/README.md"
     assert.equal(expected, status:sub(-#expected))
   end)
 end)


### PR DESCRIPTION
Currently when calling `:OpenInGHFile` the command will always append `#LX` to the URL which is not always wanted as sometimes you just want a link to the file not the specific line your cursor resides on.

This PR changes the behaviour in such a way that when you're not selecting lines when calling the command it won't append line numbers to the URL. If you are selecting something in visual mode it will append the lines to the URL.

An addition to this PR is that I've gotten rid of some camelCasing as well as a typo in a certain function.