### PR TITLE
Added hash mark uri encoding for branch name

### DIFF
--- a/lua/openingh/utils.lua
+++ b/lua/openingh/utils.lua
@@ -77,17 +77,21 @@ end
 -- Returns the current branch or commit if they are available on remote
 -- otherwise this will return the default branch of the repo
 function M.get_current_branch_or_commit()
-  local current_branch = get_current_branch()
-  if current_branch ~= "HEAD" and M.is_branch_upstreamed(current_branch) then
-    return current_branch
+  local core = function()
+    local current_branch = get_current_branch()
+    if current_branch ~= "HEAD" and M.is_branch_upstreamed(current_branch) then
+      return current_branch
+    end
+
+    local commit_hash = get_current_commit_hash()
+    if current_branch == "HEAD" and M.is_commit_upstreamed(commit_hash) then
+      return commit_hash
+    end
+
+    return M.get_default_branch()
   end
 
-  local commit_hash = get_current_commit_hash()
-  if current_branch == "HEAD" and M.is_commit_upstreamed(commit_hash) then
-    return commit_hash
-  end
-
-  return M.get_default_branch()
+  return string.gsub(core(), "#", "%%23")
 end
 
 -- get the active buf relative file path form the .git

--- a/tests/utils_spec.lua
+++ b/tests/utils_spec.lua
@@ -26,3 +26,26 @@ describe("is_commit_upstreamed", function()
     assert.is.True(output)
   end)
 end)
+
+describe("encode_uri_component", function()
+  it("returns the given string without any change if it doesn't contain any uri reserved characters", function()
+    local input = "asdf_12345.QWER~yuio-hjkl"
+    local output = utils.encode_uri_component(input)
+    assert.is.Equal(input, output)
+  end)
+
+  it("returns an encoded string that all non-uri-unreserved characters are converted", function()
+    local input = ""
+    for i = 0, 127 do
+      input = input .. string.char(i)
+    end
+    local output = utils.encode_uri_component(input)
+    assert.is.Equal("%00%01%02%03%04%05%06%07%08%09%0A%0B%0C%0D%0E%0F%10%11%12%13%14%15%16%17%18%19%1A%1B%1C%1D%1E%1F%20%21%22%23%24%25%26%27%28%29%2A%2B%2C-.%2F0123456789%3A%3B%3C%3D%3E%3F%40ABCDEFGHIJKLMNOPQRSTUVWXYZ%5B%5C%5D%5E_%60abcdefghijklmnopqrstuvwxyz%7B%7C%7D~%7F", output)
+  end)
+
+  it("returns encoded string for a non-ascii string input (UTF-8)", function()
+    local input = "ほげ" -- UTF-8 bytewise representation is "e3 81 bb e3 81 92" 
+    local output = utils.encode_uri_component(input)
+    assert.is.Equal("%E3%81%BB%E3%81%92", output)
+  end)
+end)


### PR DESCRIPTION
Thanks for the handy plugin.

I sometimes use branch name which includes `#` such as `feature/#{number-of-issue}_xxx`.
And if it exists then this plugin seems not work.
This pull request fixes this by url-encoding only that character.