### PR TITLE
Added an argument which prioritizes commit instead of branch

### DIFF
--- a/lua/openingh/init.lua
+++ b/lua/openingh/init.lua
@@ -23,9 +23,9 @@ function M.setup()
 end
 
 local get_current_branch_or_commit_with_priority = function(priority)
-  if (not priority) or (priority and priority == 'branch') then
+  if priority == 'branch-priority' then
     return utils.get_current_branch_or_commit()
-  elseif (priority and priority == 'branch') then
+  elseif priority == 'commit-priority' then
     return utils.get_current_commit_or_branch()
   else
     return utils.get_current_branch_or_commit()

--- a/lua/openingh/init.lua
+++ b/lua/openingh/init.lua
@@ -22,7 +22,18 @@ function M.setup()
   M.repo_url = string.format("http://%s/%s/%s", gh.host, gh.user_or_org, gh.reponame)
 end
 
+local get_current_branch_or_commit_with_priority = function(priority)
+  if (not priority) or (priority and priority == 'branch') then
+    return utils.get_current_branch_or_commit()
+  elseif (priority and priority == 'branch') then
+    return utils.get_current_commit_or_branch()
+  else
+    return utils.get_current_branch_or_commit()
+  end
+end
+
 function M.open_file(
+  priority,
   --[[optional]]
   range_start,
   --[[optional]]
@@ -43,7 +54,8 @@ function M.open_file(
     return
   end
 
-  local file_page_url = M.repo_url .. "/blob/" .. utils.get_current_branch_or_commit() .. file_path
+
+  local file_page_url = M.repo_url .. "/blob/" .. get_current_branch_or_commit_with_priority(priority) .. file_path
 
   if range_start and not range_end then
     file_page_url = file_page_url .. "#L" .. range_start
@@ -58,7 +70,7 @@ function M.open_file(
   end
 end
 
-function M.open_repo()
+function M.open_repo(priority)
   -- make sure to update the current directory
   M.setup()
   if M.is_no_git_origin then
@@ -66,7 +78,8 @@ function M.open_repo()
     return
   end
 
-  local url = M.repo_url .. "/tree/" .. utils.get_current_branch_or_commit()
+
+  local url = M.repo_url .. "/tree/" .. get_current_branch_or_commit_with_priority(priority)
   if not utils.open_url(url) then
     utils.notify("Could not open the built URL " .. url, vim.log.levels.ERROR)
   end

--- a/lua/openingh/init.lua
+++ b/lua/openingh/init.lua
@@ -22,10 +22,12 @@ function M.setup()
   M.repo_url = string.format("http://%s/%s/%s", gh.host, gh.user_or_org, gh.reponame)
 end
 
-local get_current_branch_or_commit_with_priority = function(priority)
-  if priority == 'branch-priority' then
+M.priority = { BRANCH = 'branch-priority', COMMIT = 'commit-priority', }
+
+local function get_current_branch_or_commit_with_priority(priority)
+  if priority == M.priority.BRANCH then
     return utils.get_current_branch_or_commit()
-  elseif priority == 'commit-priority' then
+  elseif priority == M.priority.COMMIT then
     return utils.get_current_commit_or_branch()
   else
     return utils.get_current_branch_or_commit()

--- a/lua/openingh/utils.lua
+++ b/lua/openingh/utils.lua
@@ -96,6 +96,23 @@ function M.get_current_branch_or_commit()
   return M.encode_uri_component(M.get_default_branch())
 end
 
+-- Returns the current commit or branch if they are available on remote
+-- otherwise this will return the default branch of the repo
+-- (This function prioritizes commit than branch)
+function M.get_current_commit_or_branch()
+  local commit_hash = get_current_commit_hash()
+  if M.is_commit_upstreamed(commit_hash) then
+    return commit_hash
+  end
+
+  local current_branch = get_current_branch()
+  if current_branch ~= "HEAD" and M.is_branch_upstreamed(current_branch) then
+    return M.encode_uri_component(current_branch)
+  end
+
+  return M.encode_uri_component(M.get_default_branch())
+end
+
 -- get the active buf relative file path form the .git
 function M.get_current_relative_file_path()
   -- we only want the active buffer name

--- a/plugin/openingh.lua
+++ b/plugin/openingh.lua
@@ -37,7 +37,6 @@ end, {
 })
 
 vim.api.nvim_create_user_command("OpenInGHRepo", function()
-  print(opts)
   openingh.open_repo(opts.args)
 end, {
   nargs = '?',

--- a/plugin/openingh.lua
+++ b/plugin/openingh.lua
@@ -5,26 +5,41 @@ vim.g.openingh = true
 
 local openingh = require("openingh")
 
+local complete_list = { 'branch-priority', 'commit-priority', }
+local complete_func = function(arg_lead, _, _)
+  return vim.tbl_filter(function(item)
+    return vim.startswith(item, arg_lead)
+  end, complete_list)
+end
+
 vim.api.nvim_create_user_command("OpenInGHFile", function(opts)
   if opts.range == 0 then -- Nothing was selected
-    openingh.open_file()
+    openingh.open_file(opts.args)
   else -- Current line or block was selected
-    openingh.open_file(opts.line1, opts.line2)
+    openingh.open_file(opts.args, opts.line1, opts.line2)
   end
 end, {
   range = true,
+  nargs = '?',
+  complete = complete_func,
 })
 
 vim.api.nvim_create_user_command("OpenInGHFileLines", function(opts)
   if opts.range == 0 then -- Nothing was selected
-    openingh.open_file(opts.line1)
+    openingh.open_file(opts.args, opts.line1)
   else -- Current line or block was selected
-    openingh.open_file(opts.line1, opts.line2)
+    openingh.open_file(opts.args, opts.line1, opts.line2)
   end
 end, {
   range = true,
+  nargs = '?',
+  complete = complete_func,
 })
 
 vim.api.nvim_create_user_command("OpenInGHRepo", function()
-  openingh.open_repo()
-end, {})
+  print(opts)
+  openingh.open_repo(opts.args)
+end, {
+  nargs = '?',
+  complete = complete_func,
+})

--- a/plugin/openingh.lua
+++ b/plugin/openingh.lua
@@ -5,8 +5,8 @@ vim.g.openingh = true
 
 local openingh = require("openingh")
 
-local complete_list = { 'branch-priority', 'commit-priority', }
-local complete_func = function(arg_lead, _, _)
+local complete_list = { openingh.priority.BRANCH, openingh.priority.COMMIT, }
+local function complete_func(arg_lead, _, _)
   return vim.tbl_filter(function(item)
     return vim.startswith(item, arg_lead)
   end, complete_list)
@@ -36,7 +36,7 @@ end, {
   complete = complete_func,
 })
 
-vim.api.nvim_create_user_command("OpenInGHRepo", function()
+vim.api.nvim_create_user_command("OpenInGHRepo", function(opts)
   openingh.open_repo(opts.args)
 end, {
   nargs = '?',


### PR DESCRIPTION
I added an command argument to prioritize commit than branch.

    :OpeninGHFile commit-priority

The first point is whether this idea is okay or not, though.
I'm wondering whether the name of argument is matches to this idea.
`by-commit`, `by-branch` or some others are more preferable?

### Background

I sometimes open a page for a Repository or a File under GitHub using this plugin
to obtain a link url that I can put in a comment or something similar.

But, since that url will be typically based on the branch not commit,
if the branch changed by subsequent commits or deleted after merge,
then that address will not be able to be opened correctly.

It could be sometimes 404 or the specified lines slides up or down from where I initially intended.

Then I added a argument to prioritize commit rather than branch
so that obtained url will be available as long as that repository exists.