### PR TITLE
fix: Check local reference of remote branch first

### DIFF
--- a/lua/openingh/utils.lua
+++ b/lua/openingh/utils.lua
@@ -60,7 +60,13 @@ end
 
 -- Checks if the supplied branch is available on the remote
 function M.is_branch_upstreamed(branch)
-  local output = M.trim(vim.fn.system("git ls-remote --exit-code --heads origin " .. branch))
+  local output = M.trim(vim.fn.system("git branch -r --list origin/" .. branch))
+  if output:find(branch, 1, true) then
+    return true
+  end
+
+  -- ls-remote is more expensive so only use it as a fallback
+  output = M.trim(vim.fn.system("git ls-remote --exit-code --heads origin " .. branch))
   return output ~= ""
 end
 


### PR DESCRIPTION
This is an attempt to fix #20

git ls-remote turns out to be slow, so checking for the local remote branches first to determine if a branch exists upstream. This might not work in all cases (e.g. if a branch was deleted remotely but no fetch happened), but is probably good enough for most cases.

