### PR TITLE
Add ability to yank url into register

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.luarc.json

--- a/README.md
+++ b/README.md
@@ -45,6 +45,13 @@ end)
 - `:OpenInGHFileLines`
   - Opens the current file page in GitHub. This command supports ranges.
 
+
+## Registers
+
+All of the commands above optionally take a register, e.g. `:OpenInGHFileLines+`.
+In this case, the URL will not be opened in the browser, but put into the register given.
+This is especially useful if you're running neovim on a remote machine, but want to open the URL locally.
+
 ## Usage
 
 You can call the commands directly or define mappings them:

--- a/lua/openingh/init.lua
+++ b/lua/openingh/init.lua
@@ -34,7 +34,7 @@ local function get_current_branch_or_commit_with_priority(priority)
   end
 end
 
-function M.open_file(
+function M.get_file_url(
   priority,
   --[[optional]]
   range_start,
@@ -67,12 +67,10 @@ function M.open_file(
     file_page_url = file_page_url .. "#L" .. range_start .. "-L" .. range_end
   end
 
-  if not utils.open_url(file_page_url) then
-    utils.notify("Could not open the built URL " .. file_page_url, vim.log.levels.ERROR)
-  end
+  return file_page_url
 end
 
-function M.open_repo(priority)
+function M.get_repo_url(priority)
   -- make sure to update the current directory
   M.setup()
   if M.is_no_git_origin then
@@ -80,8 +78,11 @@ function M.open_repo(priority)
     return
   end
 
-
   local url = M.repo_url .. "/tree/" .. get_current_branch_or_commit_with_priority(priority)
+  return url
+end
+
+function M.open_url(url)
   if not utils.open_url(url) then
     utils.notify("Could not open the built URL " .. url, vim.log.levels.ERROR)
   end

--- a/plugin/openingh.lua
+++ b/plugin/openingh.lua
@@ -21,8 +21,14 @@ vim.api.nvim_create_user_command("OpenInGHFile", function(opts)
     url = openingh.get_file_url(opts.args, opts.line1, opts.line2)
   end
 
-  openingh.open_url(url)
+  if opts.reg == "" then
+    openingh.open_url(url)
+  else
+    vim.fn.setreg(opts.reg, url)
+    print("URL yanked")
+  end
 end, {
+  register = true,
   range = true,
   nargs = '?',
   complete = complete_func,
@@ -37,16 +43,30 @@ vim.api.nvim_create_user_command("OpenInGHFileLines", function(opts)
     url = openingh.get_file_url(opts.args, opts.line1, opts.line2)
   end
 
-  openingh.open_url(url)
+  if opts.reg == "" then
+    openingh.open_url(url)
+  else
+    vim.fn.setreg(opts.reg, url)
+    print("URL yanked")
+  end
 end, {
+  register = true,
   range = true,
   nargs = '?',
   complete = complete_func,
 })
 
 vim.api.nvim_create_user_command("OpenInGHRepo", function(opts)
-  openingh.open_url(openingh.get_repo_url(opts.args))
+  local url = openingh.get_repo_url(opts.args)
+
+  if opts.reg == "" then
+    openingh.open_url(url)
+  else
+    vim.fn.setreg(opts.reg, url)
+    print("URL yanked")
+  end
 end, {
+  register = true,
   nargs = '?',
   complete = complete_func,
 })

--- a/plugin/openingh.lua
+++ b/plugin/openingh.lua
@@ -13,11 +13,15 @@ local function complete_func(arg_lead, _, _)
 end
 
 vim.api.nvim_create_user_command("OpenInGHFile", function(opts)
+  local url
+
   if opts.range == 0 then -- Nothing was selected
-    openingh.open_file(opts.args)
-  else -- Current line or block was selected
-    openingh.open_file(opts.args, opts.line1, opts.line2)
+    url = openingh.get_file_url(opts.args)
+  else                    -- Current line or block was selected
+    url = openingh.get_file_url(opts.args, opts.line1, opts.line2)
   end
+
+  openingh.open_url(url)
 end, {
   range = true,
   nargs = '?',
@@ -25,11 +29,15 @@ end, {
 })
 
 vim.api.nvim_create_user_command("OpenInGHFileLines", function(opts)
+  local url
+
   if opts.range == 0 then -- Nothing was selected
-    openingh.open_file(opts.args, opts.line1)
-  else -- Current line or block was selected
-    openingh.open_file(opts.args, opts.line1, opts.line2)
+    url = openingh.get_file_url(opts.args, opts.line1)
+  else                    -- Current line or block was selected
+    url = openingh.get_file_url(opts.args, opts.line1, opts.line2)
   end
+
+  openingh.open_url(url)
 end, {
   range = true,
   nargs = '?',
@@ -37,7 +45,7 @@ end, {
 })
 
 vim.api.nvim_create_user_command("OpenInGHRepo", function(opts)
-  openingh.open_repo(opts.args)
+  openingh.open_url(openingh.get_repo_url(opts.args))
 end, {
   nargs = '?',
   complete = complete_func,

--- a/plugin/openingh.lua
+++ b/plugin/openingh.lua
@@ -25,7 +25,7 @@ vim.api.nvim_create_user_command("OpenInGHFile", function(opts)
     openingh.open_url(url)
   else
     vim.fn.setreg(opts.reg, url)
-    print("URL yanked")
+    print("URL put into register " .. opts.reg)
   end
 end, {
   register = true,
@@ -47,7 +47,7 @@ vim.api.nvim_create_user_command("OpenInGHFileLines", function(opts)
     openingh.open_url(url)
   else
     vim.fn.setreg(opts.reg, url)
-    print("URL yanked")
+    print("URL put into register " .. opts.reg)
   end
 end, {
   register = true,
@@ -63,7 +63,7 @@ vim.api.nvim_create_user_command("OpenInGHRepo", function(opts)
     openingh.open_url(url)
   else
     vim.fn.setreg(opts.reg, url)
-    print("URL yanked")
+    print("URL put into register " .. opts.reg)
   end
 end, {
   register = true,


### PR DESCRIPTION
Hello,

first of all great plugin!

I often use neovim remote over ssh. In this case, the plugin does not work as intended, since I can't open the browser in my headless workstation.

Therefore, I added the ability to copy the created URL into a register, where I can then paste it into a browser on my local machine.

Feel free to merge this if you like, I also understand if this does not fit the intention of the plugin. If that's the case, I'm happy to maintain my little fork.

Greetings.

