### PR TITLE
Feature/commit priority with bang

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,16 @@ All of the commands above optionally take a register, e.g. `:OpenInGHFileLines+`
 In this case, the URL will not be opened in the browser, but put into the register given.
 This is especially useful if you're running neovim on a remote machine, but want to open the URL locally.
 
+## Priority
+
+At first, this plugin try to identify the page url based on the current branch you are working in,
+and if it fails then switches its base to commit.
+
+This behavior can be inverted via bang `!`, e.g. `:OpenInGHFile!`.
+
+Since commit based url tends to have long durablity compared to branch based one, it can be useful in some situation.
+It won't be affected by subsequent commits, branch deletion after merge, and so on.
+
 ## Usage
 
 You can call the commands directly or define mappings them:

--- a/lua/openingh/init.lua
+++ b/lua/openingh/init.lua
@@ -22,7 +22,7 @@ function M.setup()
   M.repo_url = string.format("http://%s/%s/%s", gh.host, gh.user_or_org, gh.reponame)
 end
 
-M.priority = { BRANCH = 'branch-priority', COMMIT = 'commit-priority', }
+M.priority = { BRANCH = 1, COMMIT = 2, }
 
 local function get_current_branch_or_commit_with_priority(priority)
   if priority == M.priority.BRANCH then

--- a/plugin/openingh.lua
+++ b/plugin/openingh.lua
@@ -5,20 +5,22 @@ vim.g.openingh = true
 
 local openingh = require("openingh")
 
-local complete_list = { openingh.priority.BRANCH, openingh.priority.COMMIT, }
-local function complete_func(arg_lead, _, _)
-  return vim.tbl_filter(function(item)
-    return vim.startswith(item, arg_lead)
-  end, complete_list)
+local function judge_priority(bang)
+  -- When the command executed with bang `!`, prioritizes commit rather than branch.
+  if bang then
+    return openingh.priority.COMMIT
+  else
+    return openingh.priority.BRANCH
+  end
 end
 
 vim.api.nvim_create_user_command("OpenInGHFile", function(opts)
   local url
 
   if opts.range == 0 then -- Nothing was selected
-    url = openingh.get_file_url(opts.args)
+    url = openingh.get_file_url(judge_priority(opts.bang))
   else                    -- Current line or block was selected
-    url = openingh.get_file_url(opts.args, opts.line1, opts.line2)
+    url = openingh.get_file_url(judge_priority(opts.bang), opts.line1, opts.line2)
   end
 
   if opts.reg == "" then
@@ -30,17 +32,16 @@ vim.api.nvim_create_user_command("OpenInGHFile", function(opts)
 end, {
   register = true,
   range = true,
-  nargs = '?',
-  complete = complete_func,
+  bang = true,
 })
 
 vim.api.nvim_create_user_command("OpenInGHFileLines", function(opts)
   local url
 
   if opts.range == 0 then -- Nothing was selected
-    url = openingh.get_file_url(opts.args, opts.line1)
+    url = openingh.get_file_url(judge_priority(opts.bang), opts.line1)
   else                    -- Current line or block was selected
-    url = openingh.get_file_url(opts.args, opts.line1, opts.line2)
+    url = openingh.get_file_url(judge_priority(opts.bang), opts.line1, opts.line2)
   end
 
   if opts.reg == "" then
@@ -52,12 +53,11 @@ vim.api.nvim_create_user_command("OpenInGHFileLines", function(opts)
 end, {
   register = true,
   range = true,
-  nargs = '?',
-  complete = complete_func,
+  bang = true,
 })
 
 vim.api.nvim_create_user_command("OpenInGHRepo", function(opts)
-  local url = openingh.get_repo_url(opts.args)
+  local url = openingh.get_repo_url(judge_priority(opts.bang))
 
   if opts.reg == "" then
     openingh.open_url(url)
@@ -67,6 +67,5 @@ vim.api.nvim_create_user_command("OpenInGHRepo", function(opts)
   end
 end, {
   register = true,
-  nargs = '?',
-  complete = complete_func,
+  bang = true,
 })


### PR DESCRIPTION
A few days ago when I update this plugin, the feature that I previously added, which prioritize commit rather than branch, is no longer worked...

It seems that when yank url into register feature added, it made the register expression acceptable for each command,
and unfortunately added option `register = true` eats arguments as a part of register.

Then I changed the way to control priority from an argument to bang.

related pull request: #19