### PR TITLE
Fix: escape bracket in path

### DIFF
--- a/lua/openingh/init.lua
+++ b/lua/openingh/init.lua
@@ -3,7 +3,7 @@ local M = {}
 
 function M.setup()
   -- get the current working directory and set the url
-  local current_buffer = vim.fn.expand("%:p:h")
+  local current_buffer = vim.fn.expand("%:p:h"):gsub("%[", "\\["):gsub("%]", "\\]")
   local repo_url = vim.fn.system("git -C " .. current_buffer .. " config --get remote.origin.url")
 
   if repo_url:len() == 0 then
@@ -55,7 +55,6 @@ function M.get_file_url(
     utils.notify("There is no active file to open!", vim.log.levels.ERROR)
     return
   end
-
 
   local file_page_url = M.repo_url .. "/blob/" .. get_current_branch_or_commit_with_priority(priority) .. file_path
 

--- a/lua/openingh/init.lua
+++ b/lua/openingh/init.lua
@@ -56,6 +56,7 @@ function M.get_file_url(
     return
   end
 
+
   local file_page_url = M.repo_url .. "/blob/" .. get_current_branch_or_commit_with_priority(priority) .. file_path
 
   if range_start and not range_end then


### PR DESCRIPTION
## The error
I got this error while executing `:OpenInGHFilesLines`
```
Error parsing GitHub remote URL
Error executing Lua callback: ...ocal/share/nvim/lazy/openingh.nvim/lua/openingh/init.lua:59: attempt to concatenate field 'repo
_url' (a nil value)
stack traceback:
        ...ocal/share/nvim/lazy/openingh.nvim/lua/openingh/init.lua:59: in function 'get_file_url'
        ....local/share/nvim/lazy/openingh.nvim/plugin/openingh.lua:42: in function <....local/share/nvim/lazy/openingh.nvim/plu
gin/openingh.lua:38>
```

## The problem
The path to the file contains square brackets, it's common in next.js apps. (`./src/components/[user]/profile`)
The `git -C <current_buffer> config --get remote.origin.url` command fails with `zsh: bad pattern ...` because it tries to interpret the braces as a regex (?).

## The solution
Escape the square brackets in the current buffer path, before executing the git command.