### PR TITLE
make test easier to run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: lint
+.PHONY: lint fmt test clean
 
 lint:
 	luacheck lua
@@ -6,5 +6,18 @@ lint:
 fmt:
 	stylua --config-path stylua.toml --glob 'lua/**/*.lua' -- lua
 
-test:
+/tmp/openingh.nvim/:
+	mkdir -p /tmp/openingh.nvim
+
+/tmp/openingh.nvim/plenary.nvim/: /tmp/openingh.nvim/
+	git clone --depth 1 https://github.com/nvim-lua/plenary.nvim /tmp/openingh.nvim/plenary.nvim
+
+/tmp/openingh.nvim/pack/vendor/opt/openingh.nvim/: /tmp/openingh.nvim/
+	mkdir -p /tmp/openingh.nvim/pack/vendor/opt
+	ln -s $$PWD /tmp/openingh.nvim/pack/vendor/opt
+
+test: /tmp/openingh.nvim/plenary.nvim/ /tmp/openingh.nvim/pack/vendor/opt/openingh.nvim/
 	nvim --headless --noplugin -u tests/minimal.vim -c "PlenaryBustedDirectory tests/ {minimal_init = 'tests/minimal.vim'}"
+
+clean:
+	rm -rf /tmp/openingh.nvim

--- a/tests/minimal.vim
+++ b/tests/minimal.vim
@@ -1,5 +1,5 @@
-set rtp +=.
-set rtp +=../plenary.nvim/
+set rtp+=/tmp/openingh.nvim/plenary.nvim/
+set packpath+=/tmp/openingh.nvim/
 
 
 runtime! plugin/plenary.vim


### PR DESCRIPTION
Running the test from a fresh clone raises the following:
```
$ make test
nvim --headless --noplugin -u tests/minimal.vim -c "PlenaryBustedDirectory tests/ {minimal_init = 'tests/minimal.vim'}"
Error detected while processing /home/dfavato/workspace/my/openingh.nvim/tests/minimal.vim:
line   21:
E5108: Error executing lua [string ":lua"]:1: module 'plenary/busted' not found:
        no field package.preload['plenary/busted']
        no file './plenary/busted.lua'
        no file '/home/runner/work/neovim/neovim/.deps/usr/share/luajit-2.1/plenary/busted.lua'
        no file '/usr/local/share/lua/5.1/plenary/busted.lua'
        no file '/usr/local/share/lua/5.1/plenary/busted/init.lua'
        no file '/home/runner/work/neovim/neovim/.deps/usr/share/lua/5.1/plenary/busted.lua'
        no file '/home/runner/work/neovim/neovim/.deps/usr/share/lua/5.1/plenary/busted/init.lua'
        no file './plenary/busted.so'
        no file '/usr/local/lib/lua/5.1/plenary/busted.so'
        no file '/home/runner/work/neovim/neovim/.deps/usr/lib/lua/5.1/plenary/busted.so'
        no file '/usr/local/lib/lua/5.1/loadall.so'
stack traceback:
        [C]: in function 'require'
        [string ":lua"]:1: in main chunk
Error detected while processing command line:
E492: Not an editor command: PlenaryBustedDirectory tests/ {minimal_init = 'tests/minimal.vim'}^Cmake: *** [Makefile:10: test] 
```

These are the changes I did to make it run.
