### PR TITLE
Add support for ssh hostnames, add tests for `parse_gh_remote`

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,7 @@ jobs:
   luacheck:
     name: Luacheck
     # The type of runner that the job will run on
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/lua/openingh/init.lua
+++ b/lua/openingh/init.lua
@@ -20,7 +20,12 @@ function M.setup()
     return
   end
 
-  M.repo_url = string.format("http://%s/%s/%s", gh.host, gh.user_or_org, gh.reponame)
+  local resolved_host = gh.host
+  if gh.protocol == "ssh" then
+    resolved_host = utils.resolve_ssh_host(gh.host)
+  end
+
+  M.repo_url = string.format("http://%s/%s/%s", resolved_host, gh.user_or_org, gh.reponame)
 end
 
 M.priority = { BRANCH = 1, COMMIT = 2 }

--- a/lua/openingh/utils.lua
+++ b/lua/openingh/utils.lua
@@ -43,6 +43,23 @@ function M.parse_gh_remote(url)
   -- ssh://org-12345@some.github.com/org/reponame.git
 
   -- pattern reference: https://www.lua.org/manual/5.4/manual.html#6.4.1
+  --
+  -- notes:
+  -- ^     matches beginning of the string
+  -- [^@]+ matches one or more characters that are not "@"
+  -- [^:]+ matches one or more characters that are not ":"
+  -- (.+)  matches any character one or more times
+  -- %S+   matches one or more non-whitespace characters
+  --
+  -- same patterns with spacing for readability:
+  --   git   @ github.com : user_or_org / reponame.git
+  -- ^ [^@]+ @ ([^:]+)    : (.+)        / (%S+)
+  --
+  --   https://  github.com / user_or_org / reponame
+  -- ^ https?:// ([^/]+)    / (.+)        / (%S+)
+  --
+  --   ssh:// git   @ github.com / user_or_org / reponame.git
+  -- ^ ssh:// [^@]+ @ ([^/]+)    / (.+)        / (%S+)
   local protocol = "ssh"
   local pattern = "^[^@]+@([^:]+):(.+)/(%S+)"
   if string.find(url, "^https?://") then

--- a/tests/utils_spec.lua
+++ b/tests/utils_spec.lua
@@ -52,9 +52,16 @@ end)
 
 
 describe("parse_gh_remote", function ()
+    it("test invalid input", function ()
+        local url = "invalid remote url"
+        local output = utils.parse_gh_remote(url)
+        assert.is.Nil(output)
+    end)
+
     it("test http format", function ()
         local url = "http://github.com/user/digital_repo.git"
         local output = utils.parse_gh_remote(url)
+        assert.is.Equal("http", output.protocol)
         assert.is.Equal("github.com", output.host)
         assert.is.Equal("user", output.user_or_org)
         assert.is.Equal("digital_repo", output.reponame)
@@ -63,23 +70,125 @@ describe("parse_gh_remote", function ()
     it("test https format", function ()
         local url = "https://github.com/user/digital_repo"
         local output = utils.parse_gh_remote(url)
+        assert.is.Equal("http", output.protocol)
         assert.is.Equal("github.com", output.host)
         assert.is.Equal("user", output.user_or_org)
         assert.is.Equal("digital_repo", output.reponame)
     end)
 
-    it("test ssh format", function ()
-        local url = "ssh://git@some.gitlab.com/user/digital_repo.git"
+    it("test https format with subdomain", function ()
+        local url = "https://some.github.com/user/digital_repo"
         local output = utils.parse_gh_remote(url)
+        assert.is.Equal("http", output.protocol)
+        assert.is.Equal("some.github.com", output.host)
+        assert.is.Equal("user", output.user_or_org)
+        assert.is.Equal("digital_repo", output.reponame)
+    end)
+
+    it("test https format with subgroup", function ()
+        local url = "https://gitlab.com/org/group/digital_repo"
+        local output = utils.parse_gh_remote(url)
+        assert.is.Equal("http", output.protocol)
+        assert.is.Equal("gitlab.com", output.host)
+        assert.is.Equal("org/group", output.user_or_org)
+        assert.is.Equal("digital_repo", output.reponame)
+    end)
+
+    it("test https format with subdomain, subgroup, and suffix", function ()
+        local url = "https://some.gitlab.com/org/group/digital_repo.git"
+        local output = utils.parse_gh_remote(url)
+        assert.is.Equal("http", output.protocol)
         assert.is.Equal("some.gitlab.com", output.host)
+        assert.is.Equal("org/group", output.user_or_org)
+        assert.is.Equal("digital_repo", output.reponame)
+    end)
+
+    it("test ssh format", function ()
+        local url = "ssh://git@github.com/user/digital_repo.git"
+        local output = utils.parse_gh_remote(url)
+        assert.is.Equal("ssh", output.protocol)
+        assert.is.Equal("github.com", output.host)
+        assert.is.Equal("user", output.user_or_org)
+        assert.is.Equal("digital_repo", output.reponame)
+    end)
+
+    it("test ssh format without suffix", function ()
+        local url = "ssh://git@github.com/user/digital_repo"
+        local output = utils.parse_gh_remote(url)
+        assert.is.Equal("ssh", output.protocol)
+        assert.is.Equal("github.com", output.host)
+        assert.is.Equal("user", output.user_or_org)
+        assert.is.Equal("digital_repo", output.reponame)
+    end)
+
+    it("test ssh format with custom user, subdomain, subgroup, and suffix", function ()
+        local url = "ssh://my-user123@some.github.com/org/group/digital_repo"
+        local output = utils.parse_gh_remote(url)
+        assert.is.Equal("ssh", output.protocol)
+        assert.is.Equal("some.github.com", output.host)
+        assert.is.Equal("org/group", output.user_or_org)
+        assert.is.Equal("digital_repo", output.reponame)
+    end)
+
+    it("test ssh format with custom host", function ()
+        local url = "ssh://git@work/user/digital_repo"
+        local output = utils.parse_gh_remote(url)
+        assert.is.Equal("ssh", output.protocol)
+        assert.is.Equal("work", output.host)
         assert.is.Equal("user", output.user_or_org)
         assert.is.Equal("digital_repo", output.reponame)
     end)
 
     it("test git@ format", function ()
-        local url = "git@github.com/user/digital_repo.git"
+        local url = "git@github.com:user/digital_repo.git"
         local output = utils.parse_gh_remote(url)
+        assert.is.Equal("ssh", output.protocol)
         assert.is.Equal("github.com", output.host)
+        assert.is.Equal("user", output.user_or_org)
+        assert.is.Equal("digital_repo", output.reponame)
+    end)
+
+    it("test git@ format without suffix", function ()
+        local url = "git@github.com:user/digital_repo"
+        local output = utils.parse_gh_remote(url)
+        assert.is.Equal("ssh", output.protocol)
+        assert.is.Equal("github.com", output.host)
+        assert.is.Equal("user", output.user_or_org)
+        assert.is.Equal("digital_repo", output.reponame)
+    end)
+
+    it("test git@ format with subdomain", function ()
+        local url = "git@some.github.com:user/digital_repo.git"
+        local output = utils.parse_gh_remote(url)
+        assert.is.Equal("ssh", output.protocol)
+        assert.is.Equal("some.github.com", output.host)
+        assert.is.Equal("user", output.user_or_org)
+        assert.is.Equal("digital_repo", output.reponame)
+    end)
+
+    it("test git@ format with subgroup", function ()
+        local url = "git@gitlab.com:org/group/digital_repo.git"
+        local output = utils.parse_gh_remote(url)
+        assert.is.Equal("ssh", output.protocol)
+        assert.is.Equal("gitlab.com", output.host)
+        assert.is.Equal("org/group", output.user_or_org)
+        assert.is.Equal("digital_repo", output.reponame)
+    end)
+
+    it("test git@ format with custom user", function ()
+        local url = "my-user123@some.github.com:user/digital_repo.git"
+        local output = utils.parse_gh_remote(url)
+        assert.is.Equal("ssh", output.protocol)
+        assert.is.Equal("some.github.com", output.host)
+        assert.is.Equal("user", output.user_or_org)
+        assert.is.Equal("digital_repo", output.reponame)
+    end)
+
+    it("test git@ format with custom host", function ()
+        local url = "git@work:user/digital_repo.git"
+        local output = utils.parse_gh_remote(url)
+        assert.is.Equal("ssh", output.protocol)
+        assert.is.Equal("work", output.host)
         assert.is.Equal("user", output.user_or_org)
         assert.is.Equal("digital_repo", output.reponame)
     end)


### PR DESCRIPTION
- Adds support for ssh hostnames
- Makes `parse_gh_remote` accept hostnames that do not include dots
- Adds tests for `parse_gh_remote`

Closes #9

## Testing

![image](https://github.com/user-attachments/assets/4b9110f2-bcf4-4d6d-ab39-c3bc5125a720)

`:OpenInGHFileLines` correctly opens `http://github.com/bensengupta/dotfiles/blob/main/.config/nvim/init.lua#L336` instead of `http://personalgit/bensengupta/dotfiles/blob/main/.config/nvim/init.lua#L336`

Regular ssh and https remote URL also works as expected
```sh
# both of these have been tested
git remote set-url origin git@github.com:bensengupta/dotfiles.git
git remote set-url origin https://github.com/bensengupta/dotfiles.git
```