### PR TITLE
Add OpenInGHCommit command to open any commit in the repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ end)
 - `:OpenInGHRepo`
   - Opens the project's git repository page in GitHub.
 
+- `:OpenInGHCommit "<COMMIT_SHA>"`
+  - Opens the commit sha, passed as its first argument, in GitHub. The sha must be in quotes.
+
 - `:OpenInGHFile`
   - Opens the current file page in GitHub. This command supports ranges.
 

--- a/lua/openingh/init.lua
+++ b/lua/openingh/init.lua
@@ -94,6 +94,18 @@ function M.get_repo_url(priority)
   return url
 end
 
+function M.get_commit_url(commit)
+  -- make sure to update the current directory
+  M.setup()
+  if M.is_no_git_origin then
+    utils.print_no_remote_message()
+    return
+  end
+
+  local url = M.repo_url .. "/commit/" .. commit
+  return url
+end
+
 function M.open_url(url)
   if not utils.open_url(url) then
     utils.notify("Could not open the built URL " .. url, vim.log.levels.ERROR)

--- a/plugin/openingh.lua
+++ b/plugin/openingh.lua
@@ -73,3 +73,20 @@ end, {
   register = vim.g.openingh_copy_to_register,
   bang = true,
 })
+
+vim.api.nvim_create_user_command("OpenInGHCommit", function(opts)
+  local url
+
+  local commit = opts.fargs[1]
+  url = openingh.get_commit_url(commit)
+
+  if opts.reg == "" then
+    openingh.open_url(url)
+  else
+    vim.fn.setreg(opts.reg, url)
+    print("URL put into register " .. opts.reg)
+  end
+end, {
+  register = vim.g.openingh_copy_to_register,
+  bang = true,
+})

--- a/tests/openingh_spec.lua
+++ b/tests/openingh_spec.lua
@@ -73,3 +73,12 @@ describe("OpenInGHRepo", function()
     assert.truthy(status)
   end)
 end)
+
+describe("OpenInGHCommit", function()
+  it("opens a URL with a link to the commit specified", function()
+    vim.cmd('OpenInGHCommit "1b9ffd2"')
+    local status = vim.g.OPENINGH_RESULT
+    local expected = "/commit/1b9ffd2"
+    assert.equal(expected, status:sub(-#expected))
+  end)
+end)


### PR DESCRIPTION
Adds the ability to open a git commit as specified by the sha passed as the first argument to `OpenInGHCommit`.

In the repo `Almo7aya/openingh.nvim` running the command `:OpenInGHCommit "1b9ffd2"` will open the url `https://github.com/Almo7aya/openingh.nvim/commit/1b9ffd2`.

I included a test but I'm not sure about it. If there's anything I should change please let me know.

Addresses #47 